### PR TITLE
Accept both v2 and v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@weblogin/trendchart-elements",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@weblogin/trendchart-elements",
-            "version": "1.1.0",
+            "version": "2.0.0",
             "license": "MIT",
             "dependencies": {
-                "lit": "^2.0.2"
+                "lit": "^2.8.0 || ^3.0.0"
             },
             "devDependencies": {
                 "@rollup/plugin-node-resolve": "^15.0.2",
@@ -123,16 +123,16 @@
             "dev": true
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
-            "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+            "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
         },
         "node_modules/@lit/reactive-element": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-            "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+            "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
@@ -406,9 +406,9 @@
             }
         },
         "node_modules/@types/trusted-types": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-            "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/uglify-js": {
             "version": "3.17.1",
@@ -673,12 +673,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -1128,9 +1128,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -1354,9 +1354,9 @@
             "dev": true
         },
         "node_modules/ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+            "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
             "dev": true
         },
         "node_modules/is-arrayish": {
@@ -1673,29 +1673,29 @@
             }
         },
         "node_modules/lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+            "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
             "dependencies": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
+                "@lit/reactive-element": "^2.0.4",
+                "lit-element": "^4.0.4",
+                "lit-html": "^3.1.2"
             }
         },
         "node_modules/lit-element": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.1.tgz",
-            "integrity": "sha512-Gl+2409uXWbf7n6cCl7Kzasm7zjT9xmdwi2BhLNi70sRKAgRkqueDu5mSIH3hPYMM0/vqBCdPXod3NbGkRA2ww==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+            "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
             "dependencies": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.7.0"
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.0.4",
+                "lit-html": "^3.1.2"
             }
         },
         "node_modules/lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+            "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
             "dependencies": {
                 "@types/trusted-types": "^2.0.2"
             }
@@ -1865,9 +1865,9 @@
             }
         },
         "node_modules/normalize-package-data/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -2308,13 +2308,10 @@
             ]
         },
         "node_modules/semver": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-            "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -2711,9 +2708,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "dev": true,
             "engines": {
                 "node": ">=8.3.0"
@@ -2875,16 +2872,16 @@
             }
         },
         "@lit-labs/ssr-dom-shim": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz",
-            "integrity": "sha512-92uQ5ARf7UXYrzaFcAX3T2rTvaS9Z1//ukV+DqjACM4c8s0ZBQd7ayJU5Dh2AFLD/Ayuyz4uMmxQec8q3U4Ong=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+            "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
         },
         "@lit/reactive-element": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-            "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+            "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
             "requires": {
-                "@lit-labs/ssr-dom-shim": "^1.0.0"
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
             }
         },
         "@rollup/plugin-node-resolve": {
@@ -3120,9 +3117,9 @@
             }
         },
         "@types/trusted-types": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-            "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "@types/uglify-js": {
             "version": "3.17.1",
@@ -3334,12 +3331,12 @@
             "dev": true
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "buffer-from": {
@@ -3678,9 +3675,9 @@
             "dev": true
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
@@ -3839,9 +3836,9 @@
             "dev": true
         },
         "ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==",
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+            "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
             "dev": true
         },
         "is-arrayish": {
@@ -4084,29 +4081,29 @@
             }
         },
         "lit": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-            "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.4.tgz",
+            "integrity": "sha512-q6qKnKXHy2g1kjBaNfcoLlgbI3+aSOZ9Q4tiGa9bGYXq5RBXxkVTqTIVmP2VWMp29L4GyvCFm8ZQ2o56eUAMyA==",
             "requires": {
-                "@lit/reactive-element": "^1.6.0",
-                "lit-element": "^3.3.0",
-                "lit-html": "^2.8.0"
+                "@lit/reactive-element": "^2.0.4",
+                "lit-element": "^4.0.4",
+                "lit-html": "^3.1.2"
             }
         },
         "lit-element": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.1.tgz",
-            "integrity": "sha512-Gl+2409uXWbf7n6cCl7Kzasm7zjT9xmdwi2BhLNi70sRKAgRkqueDu5mSIH3hPYMM0/vqBCdPXod3NbGkRA2ww==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.6.tgz",
+            "integrity": "sha512-U4sdJ3CSQip7sLGZ/uJskO5hGiqtlpxndsLr6mt3IQIjheg93UKYeGQjWMRql1s/cXNOaRrCzC2FQwjIwSUqkg==",
             "requires": {
-                "@lit-labs/ssr-dom-shim": "^1.1.0",
-                "@lit/reactive-element": "^1.3.0",
-                "lit-html": "^2.7.0"
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.0.4",
+                "lit-html": "^3.1.2"
             }
         },
         "lit-html": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-            "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.4.tgz",
+            "integrity": "sha512-yKKO2uVv7zYFHlWMfZmqc+4hkmSbFp8jgjdZY9vvR9jr4J8fH6FUMXhr+ljfELgmjpvlF7Z1SJ5n5/Jeqtc9YA==",
             "requires": {
                 "@types/trusted-types": "^2.0.2"
             }
@@ -4252,9 +4249,9 @@
             },
             "dependencies": {
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
                     "dev": true
                 }
             }
@@ -4591,13 +4588,10 @@
             "dev": true
         },
         "semver": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-            "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^6.0.0"
-            }
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true
         },
         "serialize-javascript": {
             "version": "4.0.0",
@@ -4903,9 +4897,9 @@
             }
         },
         "ws": {
-            "version": "7.5.9",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-            "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "demo": "concurrently --kill-others \"rollup --config --watch\" \"wds\""
     },
     "dependencies": {
-        "lit": "^2.0.2"
+        "lit": "^2.8.0 || ^3.0.0"
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.2",


### PR DESCRIPTION
https://lit.dev/docs/releases/upgrade/#overview

> For the vast majority of users there should be no required code changes to upgrade from Lit 2 to Lit 3. Most apps and libraries should be able to extend their npm version ranges to include both 2.x and 3.x, like "^2.7.0 || ^3.0.0".
